### PR TITLE
Rustgui reformat, neural network edges, fixed json parsing

### DIFF
--- a/rust-gui/src/main.rs
+++ b/rust-gui/src/main.rs
@@ -194,7 +194,12 @@ impl View {
                 }    
             ],
             "neural_state": {
-                "layers": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+                Layers: [
+                    [Node:{
+                        value:69,
+                        weights:[]
+                    }],
+                ]
             }
         }
         "#;

--- a/rust-gui/src/main.rs
+++ b/rust-gui/src/main.rs
@@ -193,35 +193,40 @@ impl View {
 
                 }    
             ],
-            "neural_state": {
-                "Layers": [
-                    "Layer":[
-                        "Node":{
-                            "value":3.4,
-                            "weights":[0.74,3.34,9.50],
+"neural_state": {
+        "id":7,
+        "layers": [
+            {
+                    "nodes": [
+                        {
+                                "value": 3.4,
+                                "weights": [0.74, 3.34, 9.50]
                         },
-                        Node:{
-                            value:47.2,
-                            weights:[0.89,0.16,6.7],
+                        {
+                                "value": 47.2,
+                                "weights": [0.89, 0.16, 6.7]
                         },
-                        Node:{
-                            value:33,9,
-                            weights:[6.9,5.26,2.91],
-                        },
-                    ],
-                    "Layer":[
-                        Node:{
-                            value:22.1,
-                        },
-                        Node:{
-                            value:6.4,
-                        },
-                        Node:{
-                            value:1.1,
-                        },
+                        {
+                                "value": 33.9,
+                                "weights": [6.9, 5.26, 2.91]
+                        }
                     ]
-                ]
+            },
+            {
+                    "nodes": [
+                        {
+                                "value": 22.1
+                        },
+                        {
+                                "value": 6.4
+                        },
+                        {
+                                "value": 1.1
+                        }
+                    ]
             }
+        ]
+    }
         }
         "#;
         let json_data: SimulationData =

--- a/rust-gui/src/main.rs
+++ b/rust-gui/src/main.rs
@@ -194,11 +194,32 @@ impl View {
                 }    
             ],
             "neural_state": {
-                Layers: [
-                    [Node:{
-                        value:69,
-                        weights:[]
-                    }],
+                "Layers": [
+                    "Layer":[
+                        "Node":{
+                            "value":3.4,
+                            "weights":[0.74,3.34,9.50],
+                        },
+                        Node:{
+                            value:47.2,
+                            weights:[0.89,0.16,6.7],
+                        },
+                        Node:{
+                            value:33,9,
+                            weights:[6.9,5.26,2.91],
+                        },
+                    ],
+                    "Layer":[
+                        Node:{
+                            value:22.1,
+                        },
+                        Node:{
+                            value:6.4,
+                        },
+                        Node:{
+                            value:1.1,
+                        },
+                    ]
                 ]
             }
         }

--- a/rust-gui/src/main.rs
+++ b/rust-gui/src/main.rs
@@ -1,14 +1,13 @@
 // This is the main file for the GUI, it will be responsible for creating the GUI and handling user input
 // It is built using the iced crate.
 
-use iced::border::width;
 use iced::widget::canvas::{Canvas, Fill, Frame, Geometry, Path};
-use iced::widget::{button, canvas, column, pane_grid, row, text, Column, PaneGrid, Row, Text};
+use iced::widget::{button, canvas, column, row, text, Column, Row};
 use iced::{mouse, Color, Length, Point, Rectangle, Renderer, Size, Subscription, Theme};
 mod neural_net;
 mod sim_view;
 use iced::time;
-use neural_net::{NeuralNet, NeuralNetState};
+use neural_net::{Layer, NeuralNet};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use sim_view::{Shape, Simulation};
@@ -57,13 +56,13 @@ struct Agent {
 struct SimulationData {
     agents: Vec<Agent>,
     shapes: Vec<Shape>,
-    neural_state: NeuralNetState,
+    layers: Vec<Layer>,
 }
 
 pub fn main() -> iced::Result {
-    iced::application("Game of Life - Iced", View::update, View::view)
+    iced::application("Multi Agent Neural Evolution", View::update, View::view)
         .subscription(View::subscription)
-        .theme(|_| Theme::Dark)
+        .theme(|_| Theme::GruvboxDark)
         .antialiasing(true)
         .centered()
         .run()
@@ -193,11 +192,42 @@ impl View {
 
                 }    
             ],
-"neural_state": {
-        "id":7,
         "layers": [
+        {
+                "nodes": [
+                        {
+                                "value": 3.4,
+                                "weights": [0.74, 3.34, 9.50, 0.1]
+                        },
+                        {
+                                "value": 0.004,
+                                "weights": [0.074, 5.34, 1.50, 4.1]
+                        }
+                        
+                    ]
+            },
             {
-                    "nodes": [
+                "nodes": [
+                        {
+                                "value": 3.4,
+                                "weights": [0.74, 3.34, 9.50, 0.1]
+                        },
+                        {
+                                "value": 47.2,
+                                "weights": [0.89, 0.16, 6.7, 0.01]
+                        },
+                        {
+                                "value": 33.9,
+                                "weights": [6.9, 5.26, 2.91, 1.43]
+                        },
+                        {
+                                "value": 2.9,
+                                "weights": [69, 1.1, 3.11, 200]
+                        }
+                    ]
+            },
+            {
+                "nodes": [
                         {
                                 "value": 3.4,
                                 "weights": [0.74, 3.34, 9.50]
@@ -209,6 +239,10 @@ impl View {
                         {
                                 "value": 33.9,
                                 "weights": [6.9, 5.26, 2.91]
+                        },
+                        {
+                                "value": 2.9,
+                                "weights": [69, 1.1, 3.11]
                         }
                     ]
             },
@@ -226,7 +260,6 @@ impl View {
                     ]
             }
         ]
-    }
         }
         "#;
         let json_data: SimulationData =
@@ -236,8 +269,7 @@ impl View {
     fn update_simulation_data(&mut self, simulation_data: SimulationData) {
         self.simulation_data = simulation_data;
         self.agent_view.color = Color::from_rgb(0.0, 1.0, 0.0);
-        self.nn_view
-            .update_network(&self.simulation_data.neural_state);
+        self.nn_view.update_network(&self.simulation_data.layers);
         self.sim_view.update_sim(&self.simulation_data.shapes);
     }
     fn subscription(&self) -> Subscription<Message> {
@@ -277,7 +309,7 @@ impl NNView {
             neural_net: NeuralNet::default(),
         }
     }
-    pub fn update_network(&mut self, neural_state: &NeuralNetState) {
+    pub fn update_network(&mut self, neural_state: &Vec<Layer>) {
         self.neural_net = NeuralNet::from_data(neural_state)
     }
     pub fn draw(&self) -> Column<Message> {

--- a/rust-gui/src/neural_net/LayerInter.rs
+++ b/rust-gui/src/neural_net/LayerInter.rs
@@ -1,6 +1,6 @@
 use crate::neural_net::Layer;
 use crate::neural_net::Node;
-use iced::{widget::canvas, Rectangle, Renderer};
+use iced::{widget::canvas, Point, Rectangle, Renderer};
 
 impl Layer {
     pub fn new(nodes: Vec<Node>) -> Self {
@@ -15,8 +15,9 @@ impl Layer {
         node_radius: f32,
         padding: f32,
         bounds: Rectangle,
-    ) -> Vec<canvas::Geometry> {
+    ) -> (Vec<canvas::Geometry>, Vec<Point>) {
         let mut layer_geometry = Vec::new();
+        let mut node_coordinates = Vec::new();
 
         // Calculate total height needed for nodes + padding
         let total_node_height = (self.nodes.len() as f32) * (node_radius * 2.0);
@@ -28,14 +29,16 @@ impl Layer {
 
         for (i, node) in self.nodes().iter().enumerate() {
             let y = start_y + i as f32 * (node_radius * 2.0 + padding);
-            layer_geometry.push(node.draw(x, y, renderer, node_radius, bounds));
+            let (geometry, coordinate) = node.draw(x, y, renderer, node_radius, bounds);
+            layer_geometry.push(geometry);
+            node_coordinates.push(coordinate);
         }
         /*for (i, node) in self.nodes.iter().enumerate() {
             let y = start_y + i as f32 * (node_radius * 2.0 + padding);
             layer_geometry.push(node.draw(x, y, renderer, node_radius, bounds));
         }*/
 
-        layer_geometry
+        (layer_geometry, node_coordinates)
     }
     fn nodes(&self) -> &Vec<Node> {
         &self.nodes

--- a/rust-gui/src/neural_net/NeuralNetInter.rs
+++ b/rust-gui/src/neural_net/NeuralNetInter.rs
@@ -2,6 +2,8 @@ use crate::neural_net::Layer;
 use crate::neural_net::NeuralNet;
 use crate::neural_net::NeuralNetState;
 use crate::neural_net::Node;
+use iced::Color;
+use iced::Point;
 use iced::Rectangle;
 use iced::{widget::canvas, Renderer};
 
@@ -12,13 +14,16 @@ impl NeuralNet {
 
     pub fn draw(&self, bounds: Rectangle, renderer: &Renderer) -> Vec<canvas::Geometry> {
         let mut neural_net_geometry = Vec::new();
+        let mut node_geometry = Vec::new();
+        let mut neural_net_node_coordinates: Vec<Vec<Point>> = Vec::new();
+
         let height = bounds.height;
         let width = bounds.width;
 
         // Get the size of the largest layer for scaling
         let tallest_layer = self.layers.iter().map(|f| f.nodes.len()).max().unwrap_or(1);
 
-        let percent_pad = 0.0;
+        let percent_pad = 3.0;
         let node_radius = self.get_node_radius(height, tallest_layer as f32, percent_pad);
         let horizontal_positions = self.get_layer_positions(width, node_radius * 2.0);
 
@@ -28,7 +33,7 @@ impl NeuralNet {
         // Draw each layer
         for (i, layer) in self.layers.iter().enumerate() {
             let x_pos = horizontal_positions[i];
-            let layer_geometry = layer.draw(
+            let (layer_geometry, layer_coordinates) = layer.draw(
                 x_pos,
                 height,
                 renderer,
@@ -36,10 +41,67 @@ impl NeuralNet {
                 node_radius * percent_pad,
                 bounds,
             );
-            neural_net_geometry.extend(layer_geometry);
+            node_geometry.extend(layer_geometry);
+            neural_net_node_coordinates.push(layer_coordinates);
         }
+        neural_net_geometry.push(self.draw_edges(bounds, renderer, neural_net_node_coordinates));
+        neural_net_geometry.extend(node_geometry);
 
         neural_net_geometry
+    }
+
+    fn draw_edges(
+        &self,
+        bounds: Rectangle,
+        renderer: &Renderer,
+        coordinates: Vec<Vec<Point>>,
+    ) -> canvas::Geometry {
+        let mut frame = canvas::Frame::new(renderer, bounds.size());
+        for (i, layer) in coordinates.iter().enumerate() {
+            match coordinates.get(i + 1) {
+                None => break,
+                Some(next_layer) => {
+                    for (j, coordinate_start) in layer.iter().enumerate() {
+                        for (k, coordinate_end) in next_layer.iter().enumerate() {
+                            let weight = self.get_weight(i, j, k);
+                            if weight != 0.0 {
+                                let edge = canvas::Path::line(*coordinate_start, *coordinate_end);
+                                let intensity = (weight.tanh() + 1.0) / 2.0;
+                                let color = Color::from_rgb(
+                                    intensity as f32,
+                                    intensity as f32,
+                                    intensity as f32,
+                                );
+                                frame.fill(&edge, color);
+                                frame.stroke(
+                                    &edge,
+                                    canvas::Stroke::default()
+                                        .with_color(Color::BLACK)
+                                        .with_width(1.0),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        frame.into_geometry()
+    }
+
+    fn get_weight(&self, i: usize, j: usize, k: usize) -> f64 {
+        let weights_option = self
+            .layers
+            .get(i)
+            .unwrap()
+            .nodes
+            .get(j)
+            .unwrap()
+            .weights
+            .clone();
+        match weights_option {
+            Some(weights) => return *weights.get(k).unwrap(),
+            None => return 0.0,
+        }
     }
 
     fn get_node_radius(&self, height: f32, sections: f32, percent_pad: f32) -> f32 {

--- a/rust-gui/src/neural_net/NeuralNetInter.rs
+++ b/rust-gui/src/neural_net/NeuralNetInter.rs
@@ -27,9 +27,6 @@ impl NeuralNet {
         let node_radius = self.get_node_radius(height, tallest_layer as f32, percent_pad);
         let horizontal_positions = self.get_layer_positions(width, node_radius * 2.0);
 
-        // Draw connections between layers first (if you want to add this feature)
-        // TODO: Add connection drawing logic here
-
         // Draw each layer
         for (i, layer) in self.layers.iter().enumerate() {
             let x_pos = horizontal_positions[i];

--- a/rust-gui/src/neural_net/NeuralNetInter.rs
+++ b/rust-gui/src/neural_net/NeuralNetInter.rs
@@ -1,6 +1,5 @@
 use crate::neural_net::Layer;
 use crate::neural_net::NeuralNet;
-use crate::neural_net::NeuralNetState;
 use crate::neural_net::Node;
 use iced::Color;
 use iced::Point;
@@ -64,17 +63,11 @@ impl NeuralNet {
                             if weight != 0.0 {
                                 let edge = canvas::Path::line(*coordinate_start, *coordinate_end);
                                 let intensity = (weight.tanh() + 1.0) / 2.0;
-                                let color = Color::from_rgb(
-                                    intensity as f32,
-                                    intensity as f32,
-                                    intensity as f32,
-                                );
+                                let color = Color::from_rgb(intensity as f32, 0.0, 0.0);
                                 frame.fill(&edge, color);
                                 frame.stroke(
                                     &edge,
-                                    canvas::Stroke::default()
-                                        .with_color(Color::BLACK)
-                                        .with_width(1.0),
+                                    canvas::Stroke::default().with_color(color).with_width(1.0),
                                 );
                             }
                         }
@@ -96,7 +89,7 @@ impl NeuralNet {
             .weights
             .clone();
         match weights_option {
-            Some(weights) => return *weights.get(k).unwrap(),
+            Some(weights) => return *weights.get(k).unwrap_or(&0.0), //if None value at k, return 0.0 for index k
             None => return 0.0,
         }
     }
@@ -115,19 +108,7 @@ impl NeuralNet {
             .collect()
     }
 
-    /*
-     * @TODO need to update this function to fit weights
-     */
-    pub fn from_data(data: &NeuralNetState) -> Self {
-        let layers: Vec<Layer> = data
-            .layers
-            .iter()
-            .map(|layer| {
-                let nodes: Vec<Node> = layer.iter().map(|&value| Node::new(value)).collect();
-                Layer::new(nodes)
-            })
-            .collect();
-
-        NeuralNet::new(1, layers)
+    pub fn from_data(data: &Vec<Layer>) -> Self {
+        NeuralNet::new(1, data.clone()) //Supports ID so in the future we could have more than one network.
     }
 }

--- a/rust-gui/src/neural_net/NodeInter.rs
+++ b/rust-gui/src/neural_net/NodeInter.rs
@@ -15,7 +15,7 @@ impl Node {
         renderer: &Renderer,
         radius: f32,
         bounds: Rectangle,
-    ) -> canvas::Geometry {
+    ) -> (canvas::Geometry, Point) {
         let coordinates = Point::new(x, y);
         let mut frame = canvas::Frame::new(renderer, bounds.size());
 
@@ -35,7 +35,7 @@ impl Node {
                 .with_width(1.0),
         );
 
-        frame.into_geometry()
+        (frame.into_geometry(), coordinates)
     }
 }
 

--- a/rust-gui/src/neural_net/NodeInter.rs
+++ b/rust-gui/src/neural_net/NodeInter.rs
@@ -1,11 +1,8 @@
 use crate::neural_net::Node;
-use iced::{color, widget::canvas, Color, Point, Rectangle, Renderer, Size};
+use iced::{color, font::Weight, widget::canvas, Color, Point, Rectangle, Renderer, Size};
 impl Node {
-    pub fn new(value: f64) -> Self {
-        Self {
-            value,
-            weights: None,
-        }
+    pub fn new(value: f64, weights: Option<Vec<f64>>) -> Self {
+        Self { value, weights }
     }
 
     pub fn draw(
@@ -26,7 +23,7 @@ impl Node {
         let intensity = (self.value.tanh() + 1.0) / 2.0;
         let color = Color::from_rgb(intensity as f32, intensity as f32, intensity as f32);
 
-        // Fill and stroke the circle
+        // Fill and stroke(nice) the circle
         frame.fill(&circle, color);
         frame.stroke(
             &circle,

--- a/rust-gui/src/neural_net/mod.rs
+++ b/rust-gui/src/neural_net/mod.rs
@@ -6,7 +6,7 @@ mod LayerInter;
 mod NeuralNetInter;
 mod NodeInter;
 
-#[derive(Default, Clone)]
+#[derive(Deserialize, Clone,Default)]
 pub struct NeuralNet {
     id: u32,
     layers: Vec<Layer>,
@@ -17,12 +17,12 @@ pub struct NeuralNetState {
     pub layers: Vec<Vec<f64>>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Deserialize,Default, Clone)]
 pub struct Layer {
     nodes: Vec<Node>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Deserialize,Default, Clone)]
 pub struct Node {
     value: f64,
     weights: Option<Vec<f64>>,

--- a/rust-gui/src/neural_net/mod.rs
+++ b/rust-gui/src/neural_net/mod.rs
@@ -6,23 +6,19 @@ mod LayerInter;
 mod NeuralNetInter;
 mod NodeInter;
 
-#[derive(Deserialize, Clone,Default)]
+#[derive(Deserialize, Clone, Default)]
 pub struct NeuralNet {
     id: u32,
     layers: Vec<Layer>,
 }
 
-#[derive(Deserialize, Clone, Default)]
-pub struct NeuralNetState {
-    pub layers: Vec<Vec<f64>>,
-}
-
-#[derive(Deserialize,Default, Clone)]
+#[derive(Deserialize, Default, Clone)]
+#[serde(tag = "nodes")]
 pub struct Layer {
     nodes: Vec<Node>,
 }
 
-#[derive(Deserialize,Default, Clone)]
+#[derive(Deserialize, Default, Clone)]
 pub struct Node {
     value: f64,
     weights: Option<Vec<f64>>,


### PR DESCRIPTION
Fixed json parsing to work with weights between nodes, changed the logic for creating the neural net object to match. Fixed an issue where the color value for edges was always black, fixed an issue with attempting to unwrap None value . Also moved to grub box theme.
![image](https://github.com/user-attachments/assets/160eaad4-afe8-4ba2-89be-db0cf229d50c)
